### PR TITLE
Fix header to revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,6 @@
 <body>
     <div class="container">
         <header>
-            <div class="header-content">
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                 <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -75,36 +75,14 @@ body {
 /* Header */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 1.5rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
     position: relative;
 }
 
-.header-content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin: 0;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {


### PR DESCRIPTION
This PR fixes the header by reverting to the older version as requested in issue #2.

## Changes
- Removed "Course Materials Assistant" header title
- Removed subtitle about courses/instructors/content
- Removed horizontal border line below header
- Preserved theme toggle button functionality
- Cleaned up unused CSS classes

Fixes #2

Generated with [Claude Code](https://claude.ai/code)